### PR TITLE
Fix typos in id README

### DIFF
--- a/id/README.md
+++ b/id/README.md
@@ -1,6 +1,6 @@
-### Depercated
+### Deprecated
 
 This subdirectory contains an older version of the c4 id package this is
 deprecated in favor of github.com/Avalanche-io/c4. The newer package is
-much simpler and faster then this one, which is only kept for now to provide
-backward compatability.
+much simpler and faster than this one, which is only kept for now to provide
+backward compatibility.


### PR DESCRIPTION
## Summary
- fix heading spelling in `id/README.md`
- correct typos in documentation

## Testing
- `go test ./...` *(fails: Forbidden while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f4eff3f20832a9320ff3b29f7b753