### PR TITLE
Fix typos in store/doc.go

### DIFF
--- a/store/doc.go
+++ b/store/doc.go
@@ -1,10 +1,10 @@
-// github.com/Avalanch-io/c4/store - is a package for representing generic c4
-// storage. A C4 store abstracts away the details of data management allowing
-// c4 data consumers and producers to store and retreave c4 identified data
-// using the c4 id alone.
+// github.com/Avalanche-io/c4/store is a package for representing generic C4
+// storage. A C4 store abstracts away the details of data management,
+// allowing C4 data consumers and producers to store and retrieve
+// C4-identified data using the C4 ID alone.
 //
-// A c4 store could represent an object storage bucket, a local filesystem,
-// or the agrigation of many c4 stores. A c4 store can also be used to abstract
-// processes like encryption, creating distributed copies, and on the fly
+// A C4 store could represent an object storage bucket, a local filesystem,
+// or the aggregation of many C4 stores. A C4 store can also be used to abstract
+// processes like encryption, creating distributed copies, and on-the-fly
 // validation.
 package store


### PR DESCRIPTION
## Summary
- fix repository path in store package docs
- correct a few typos and wording issues

## Testing
- `go test ./...` *(fails: unable to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_683f4f477088832aa09ce0740f483c80