### PR TITLE
Add Synology-ready Docker build and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# VCS and CI metadata
+.git
+.github
+
+# Local/editor artifacts
+.DS_Store
+.claude
+.direnv
+.envrc
+
+# Build/test outputs
+*.out
+*.cov
+coverage.txt
+coverage.out
+coverage.html
+final_coverage.out
+overall.cov
+result
+
+# Nix and temp files
+.nix-*
+*.tmp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,11 +87,13 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-    
+          type=raw,value=latest
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
       with:
         context: .
+        # Synology compatibility: x86_64 (amd64) and ARM64
         platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,33 @@
-FROM golang:1.23-alpine AS builder
+# syntax=docker/dockerfile:1
 
-WORKDIR /app
+ARG GO_VERSION=1.24
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+WORKDIR /src
 
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go build -o c4 ./cmd/c4
+RUN set -eux; \
+	GOARM=""; \
+	if [ "${TARGETARCH}" = "arm" ] && [ -n "${TARGETVARIANT}" ]; then GOARM="${TARGETVARIANT#v}"; fi; \
+	CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" GOARM="${GOARM}" \
+		go build -trimpath -ldflags='-s -w' -o /out/c4 ./cmd/c4
 
-FROM alpine:latest
+FROM alpine:3.21
 
 RUN apk --no-cache add ca-certificates
-WORKDIR /root/
 
-COPY --from=builder /app/c4 .
+WORKDIR /data
 
-ENTRYPOINT ["./c4"]
+COPY --from=builder /out/c4 /usr/local/bin/c4
+
+VOLUME ["/data"]
+
+ENTRYPOINT ["/usr/local/bin/c4"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -173,10 +173,11 @@ docker run --rm -v "$PWD:/data:ro" c4:local -R /data
 For Synology DSM 7+ Container Manager:
 
 1. Pull `avalancheio/c4:latest` in the Registry tab.
-2. Create a project using `docker-compose.synology.yml` from this repository.
-3. Update `/volume1/data` in that file to the NAS folder you want to scan.
-4. Keep restart policy set to `no` because this is a command-style container (it exits after work is done).
-5. Run the project and view logs to collect generated C4 IDs.
+2. The published image is multi-arch and includes both `linux/amd64` (x86_64 Synology) and `linux/arm64` variants.
+3. Create a project using `docker-compose.synology.yml` from this repository.
+4. Update `/volume1/data` in that file to the NAS folder you want to scan.
+5. Keep restart policy set to `no` because this is a command-style container (it exits after work is done).
+6. Run the project and view logs to collect generated C4 IDs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,27 @@ go build -o c4 ./cmd/c4
 go test ./...
 ```
 
+### Docker (Including Synology Container Manager)
+
+```bash
+# Build from source
+docker build -t c4:local .
+
+# Identify piped data
+echo "Hello World" | docker run --rm -i c4:local
+
+# Identify files in the current directory (mounted read-only at /data)
+docker run --rm -v "$PWD:/data:ro" c4:local -R /data
+```
+
+For Synology DSM 7+ Container Manager:
+
+1. Pull `avalancheio/c4:latest` in the Registry tab.
+2. Create a project using `docker-compose.synology.yml` from this repository.
+3. Update `/volume1/data` in that file to the NAS folder you want to scan.
+4. Keep restart policy set to `no` because this is a command-style container (it exits after work is done).
+5. Run the project and view logs to collect generated C4 IDs.
+
 ---
 
 ## Testing & Quality

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -1,0 +1,10 @@
+services:
+  c4:
+    image: avalancheio/c4:latest
+    container_name: c4
+    working_dir: /data
+    volumes:
+      - /volume1/data:/data:ro
+    # Example: recursively identify files in the mounted share.
+    command: ["-R", "/data"]
+    restart: "no"


### PR DESCRIPTION
Summary:
- add a tiny Dockerfile for multi-platform builds and a `.dockerignore` tuned for the repository
- document how to build/run the image locally plus how to deploy via Synology Container Manager, including a sample compose file
- include a Synology-tailored `docker-compose.synology.yml` that mounts `/volume1/data` and runs a single identification job

Testing:
- Not run (not requested)